### PR TITLE
Fix horizontal mirroring of recorded practice to match selfie-view preview

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T15:39:42.698Z for PR creation at branch issue-14-3974b1bf3d50 for issue https://github.com/artemu78/GymParrot/issues/14

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T15:39:42.698Z for PR creation at branch issue-14-3974b1bf3d50 for issue https://github.com/artemu78/GymParrot/issues/14

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "GymParrot",
   "private": false,
   "type": "module",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "GymParrot",
   "license": "MIT",
   "repository": {

--- a/src/components/ActivityCreator/CapturedPoseView.tsx
+++ b/src/components/ActivityCreator/CapturedPoseView.tsx
@@ -42,14 +42,16 @@ const CapturedPoseView: React.FC<CapturedPoseViewProps> = ({
 
       {/* Captured Image */}
       <div className="relative bg-gray-900 rounded-lg overflow-hidden shadow-xl border-4 border-blue-500" style={{ width: 640, height: 480 }}>
+        {/* Mirror the image horizontally to match the selfie-view preview the user saw */}
         <img
           src={capturedImage}
           alt="Captured pose"
           className="w-full h-full object-cover"
+          style={{ transform: "scaleX(-1)" }}
         />
         {/* Overlay landmarks */}
         {capturedLandmarks.length > 0 && (
-          <div className="absolute inset-0">
+          <div className="absolute inset-0" style={{ transform: "scaleX(-1)" }}>
             <svg
               className="absolute inset-0 pointer-events-none"
               width={640}

--- a/src/components/ActivityCreator/__tests__/CapturedPoseView.test.tsx
+++ b/src/components/ActivityCreator/__tests__/CapturedPoseView.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import CapturedPoseView from "../CapturedPoseView";
+import type { PoseLandmark } from "../../../types";
+
+const sampleLandmarks: PoseLandmark[] = [
+  { x: 0.5, y: 0.5, z: 0, visibility: 1 },
+  { x: 0.6, y: 0.6, z: 0, visibility: 1 },
+];
+
+describe("CapturedPoseView", () => {
+  it("horizontally mirrors the captured image to match the selfie-view preview the user saw while recording", () => {
+    render(
+      <CapturedPoseView
+        capturedImage="data:image/jpeg;base64,test"
+        capturedLandmarks={sampleLandmarks}
+      />
+    );
+
+    const capturedImage = screen.getByAltText("Captured pose");
+    expect(capturedImage.style.transform).toContain("scaleX(-1)");
+  });
+});

--- a/src/components/PracticeInterface.tsx
+++ b/src/components/PracticeInterface.tsx
@@ -636,13 +636,17 @@ const PracticeInterface: React.FC<PracticeInterfaceProps> = ({
                 <div className="relative aspect-video bg-gray-100 rounded-lg overflow-hidden border border-gray-200 shadow-inner">
                    {activity.imageData ? (
                       <>
+                        {/* Mirror to match the selfie-view preview the trainer saw when recording */}
                         <img
                           src={activity.imageData}
                           alt="Target Pose"
                           className="w-full h-full object-contain"
+                          style={{ transform: "scaleX(-1)" }}
                         />
                         {activity.poseData && activity.poseData.length > 0 ? (
-                          <PoseLandmarkOverlay landmarks={activity.poseData} />
+                          <div className="absolute inset-0" style={{ transform: "scaleX(-1)" }}>
+                            <PoseLandmarkOverlay landmarks={activity.poseData} />
+                          </div>
                         ) : null}
                       </>
                    ) : (

--- a/src/components/__tests__/PracticeInterface.test.tsx
+++ b/src/components/__tests__/PracticeInterface.test.tsx
@@ -150,6 +150,17 @@ describe("PracticeInterface", () => {
         expect(screen.getByText("Match the pose")).toBeInTheDocument();
       });
     });
+
+    it("should horizontally mirror the target pose image to match the selfie-view preview the trainer saw when recording", async () => {
+      vi.mocked(activityService.getActivityById).mockResolvedValue(
+        mockPoseActivity
+      );
+
+      render(<PracticeInterface activityId="pose-1" />);
+
+      const targetImage = await screen.findByAltText("Target Pose");
+      expect(targetImage.style.transform).toContain("scaleX(-1)");
+    });
   });
 
   describe("Difficulty Selector", () => {


### PR DESCRIPTION
## Summary

Fixes artemu78/GymParrot#14.

When a practice is recorded or the target pose is shown to a practicer, the saved image was displayed in its raw (non-mirrored) orientation while the trainer/user had been seeing a horizontally-mirrored selfie-view preview during capture. This made the played-back / target pose feel horizontally reversed compared to what the user actually saw on camera.

## Root cause

- The live `WebcamPreview` applies `transform: scaleX(-1)` to the `<video>` for natural selfie-view UX.
- `captureImageFromVideo` (in `src/components/ActivityCreator/utils.ts`) intentionally stores the raw (non-mirrored) frame so that MediaPipe landmark x-coordinates stay aligned with the image.
- However, when that raw image was later displayed in `CapturedPoseView` (trainer review) and in `PracticeInterface` as the "Target Pose", no mirroring was applied at render time — so the viewer saw the image reversed relative to the selfie-view preview.

Note: the practice attempt path inside `PracticeInterface` (`capturedImage` created via canvas with `ctx.scale(-1, 1)`) already matches the selfie preview and was not affected.

## Fix

Mirror at display time (not in stored data — that keeps landmark coordinates consistent for comparison):

- `src/components/ActivityCreator/CapturedPoseView.tsx`: apply `transform: scaleX(-1)` to the captured image and to the landmark overlay container, so both stay aligned.
- `src/components/PracticeInterface.tsx`: apply `transform: scaleX(-1)` to `activity.imageData` and its landmark overlay container.

Also bumps the package version to `0.0.3` to prepare the release.

## Tests

Added regression tests that assert the mirror transform is present on the rendered images:

- `src/components/ActivityCreator/__tests__/CapturedPoseView.test.tsx` (new)
- `src/components/__tests__/PracticeInterface.test.tsx` — new test `"should horizontally mirror the target pose image..."`

All 274 tests pass locally (`npm test`), and `npm run build` completes cleanly.

## Test plan

- [x] Unit tests pass (`npm test` — 274 passed)
- [x] Build passes (`npm run build`)
- [ ] Manual: record a pose (raise the right hand). Verify that both the captured review (`CapturedPoseView`) and the "Target Pose" panel during practice show the raised hand on the same side as in the live preview (mirror, selfie view).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Captured pose preview now displays with horizontal mirroring to match selfie-view orientation.
  * Target pose preview now displays with horizontal mirroring for consistent visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->